### PR TITLE
Add the end of feed cursor; improve DB select query; fix stream_stop_event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+bin/
 build/
 develop-eggs/
 dist/
@@ -133,6 +134,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+pyvenv.cfg
 
 # Spyder project settings
 .spyderproject

--- a/server/algos/whats_alf.py
+++ b/server/algos/whats_alf.py
@@ -8,20 +8,25 @@ uri = config.WHATS_ALF_URI
 
 
 def handler(cursor: Optional[str], limit: int) -> dict:
-    posts = Post.select().order_by(Post.indexed_at.desc()).order_by(Post.cid.desc()).limit(limit)
+    posts = Post.select().order_by(Post.cid.desc()).order_by(Post.indexed_at.desc()).limit(limit)
 
     if cursor:
+        if cursor == 'eof':
+            return {
+                'cursor': 'eof',
+                'feed': []
+            }
         cursor_parts = cursor.split('::')
         if len(cursor_parts) != 2:
             raise ValueError('Malformed cursor')
 
         indexed_at, cid = cursor_parts
         indexed_at = datetime.fromtimestamp(int(indexed_at) / 1000)
-        posts = posts.where(Post.indexed_at <= indexed_at).where(Post.cid < cid)
+        posts = posts.where(((Post.indexed_at == indexed_at) & (Post.cid < cid)) | (Post.indexed_at < indexed_at))
 
     feed = [{'post': post.uri} for post in posts]
 
-    cursor = None
+    cursor = 'eof'
     last_post = posts[-1] if posts else None
     if last_post:
         cursor = f'{int(last_post.indexed_at.timestamp() * 1000)}::{last_post.cid}'

--- a/server/algos/whats_alf.py
+++ b/server/algos/whats_alf.py
@@ -5,15 +5,16 @@ from server import config
 from server.database import Post
 
 uri = config.WHATS_ALF_URI
+CURSOR_EOF = 'eof'
 
 
 def handler(cursor: Optional[str], limit: int) -> dict:
     posts = Post.select().order_by(Post.cid.desc()).order_by(Post.indexed_at.desc()).limit(limit)
 
     if cursor:
-        if cursor == 'eof':
+        if cursor == CURSOR_EOF:
             return {
-                'cursor': 'eof',
+                'cursor': CURSOR_EOF,
                 'feed': []
             }
         cursor_parts = cursor.split('::')
@@ -26,7 +27,7 @@ def handler(cursor: Optional[str], limit: int) -> dict:
 
     feed = [{'post': post.uri} for post in posts]
 
-    cursor = 'eof'
+    cursor = CURSOR_EOF
     last_post = posts[-1] if posts else None
     if last_post:
         cursor = f'{int(last_post.indexed_at.timestamp() * 1000)}::{last_post.cid}'

--- a/server/data_stream.py
+++ b/server/data_stream.py
@@ -59,7 +59,7 @@ def _get_ops_by_type(commit: models.ComAtprotoSyncSubscribeRepos.Commit) -> dict
 
 
 def run(name, operations_callback, stream_stop_event=None):
-    while stream_stop_event and not stream_stop_event.is_set():
+    while stream_stop_event is None or not stream_stop_event.is_set():
         try:
             _run(name, operations_callback, stream_stop_event)
         except FirehoseError as e:

--- a/server/data_stream.py
+++ b/server/data_stream.py
@@ -59,7 +59,7 @@ def _get_ops_by_type(commit: models.ComAtprotoSyncSubscribeRepos.Commit) -> dict
 
 
 def run(name, operations_callback, stream_stop_event=None):
-    while True:
+    while stream_stop_event and not stream_stop_event.is_set():
         try:
             _run(name, operations_callback, stream_stop_event)
         except FirehoseError as e:


### PR DESCRIPTION
Some pyvenv additions to gitignore,
better selection from the feed database,
better handling of the end of the feed (cursor),
and actually make the stream_stop_event work.