### PR TITLE
Fixes related to bsky.social migration

### DIFF
--- a/server/data_stream.py
+++ b/server/data_stream.py
@@ -91,9 +91,9 @@ def _run(name, operations_callback, stream_stop_event=None):
             return
 
         commit = parse_subscribe_repos_message(message)
-        if not commit.blocks:
-            return
         if not isinstance(commit, models.ComAtprotoSyncSubscribeRepos.Commit):
+            return
+        if not commit.blocks:
             return
 
         # update stored state every ~20 events

--- a/server/data_stream.py
+++ b/server/data_stream.py
@@ -79,7 +79,7 @@ def _run(name, operations_callback, stream_stop_event=None):
     if state:
         params = models.ComAtprotoSyncSubscribeRepos.Params(cursor=state.cursor)
 
-    client = FirehoseSubscribeReposClient(params)
+    client = FirehoseSubscribeReposClient(params,base_uri='wss://bsky.network/xrpc')
 
     if not state:
         SubscriptionState.create(service=name, cursor=0)
@@ -91,6 +91,8 @@ def _run(name, operations_callback, stream_stop_event=None):
             return
 
         commit = parse_subscribe_repos_message(message)
+        if not commit.blocks:
+            return
         if not isinstance(commit, models.ComAtprotoSyncSubscribeRepos.Commit):
             return
 


### PR DESCRIPTION
This PR points the firehose consumer to `bsky.network` until the SDK is updated to include it as the new default (closes #4), and includes a fix from the [SDK repo](https://github.com/MarshalX/atproto/issues/186) to ignore messages with empty blocks that get consumed for whatever reason. 

I'm sure these particular fixes will make their way into the SDK at some point, but this will get feeds going until then! 😊