### PR TITLE
Change default post indexing time to UTC

### DIFF
--- a/server/database.py
+++ b/server/database.py
@@ -16,7 +16,7 @@ class Post(BaseModel):
     cid = peewee.CharField()
     reply_parent = peewee.CharField(null=True, default=None)
     reply_root = peewee.CharField(null=True, default=None)
-    indexed_at = peewee.DateTimeField(default=datetime.now)
+    indexed_at = peewee.DateTimeField(default=datetime.utcnow)
 
 
 class SubscriptionState(BaseModel):


### PR DESCRIPTION
Fixes issues relating to timezone or hosting country changes that could cause posts to get indexed out of order.

Fixes #6.