### PR TITLE
Add options IGNORE_ARCHIVED_POSTS and IGNORE_REPLY_POSTS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,9 +30,9 @@ AVATAR_PATH=''
 # (Optional). Only use this if you want a service did different from did:web
 SERVICE_DID=''
 
-# (Optional).Ignore reply posts
+# (Optional). Ignore reply posts
 #IGNORE_REPLY_POSTS='true'
 
-# (Optional).Ignore posts with a created_at timestamp older than 1 day
+# (Optional). Ignore posts with a created_at timestamp older than 1 day
 # to avoid including archived posts from X/Twitter
 #IGNORE_OLD_POSTS='true'

--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,10 @@ AVATAR_PATH=''
 
 # (Optional). Only use this if you want a service did different from did:web
 SERVICE_DID=''
+
+# (Optional).Ignore reply posts
+#IGNORE_REPLY_POSTS='true'
+
+# (Optional).Ignore posts with a created_at timestamp older than 1 day
+# to avoid including archived posts from X/Twitter
+#IGNORE_OLD_POSTS='true'

--- a/server/config.py
+++ b/server/config.py
@@ -25,3 +25,18 @@ FEED_URI = os.environ.get('FEED_URI')
 if FEED_URI is None:
     raise RuntimeError('Publish your feed first (run publish_feed.py) to obtain Feed URI. '
                        'Set this URI to "FEED_URI" environment variable.')
+
+
+def _get_bool_env_var(value: str) -> bool:
+    if value is None:
+        return False
+
+    normalized_value = value.strip().lower()
+    if normalized_value in {'1', 'true', 't', 'yes', 'y'}:
+        return True
+
+    return False
+
+
+IGNORE_ARCHIVED_POSTS = _get_bool_env_var(os.environ.get('IGNORE_ARCHIVED_POSTS'))
+IGNORE_REPLY_POSTS = _get_bool_env_var(os.environ.get('IGNORE_REPLY_POSTS'))

--- a/server/data_filter.py
+++ b/server/data_filter.py
@@ -1,9 +1,20 @@
+import datetime
+
 from collections import defaultdict
 
 from atproto import models
 
 from server.logger import logger
 from server.database import db, Post
+
+
+def is_archive_record(record):
+    archived_threshold = datetime.timedelta(minutes=5)
+    created_at = datetime.datetime.fromisoformat(record.created_at)
+    now = datetime.datetime.now(datetime.UTC)
+
+    return now - created_at >= archived_threshold
+
 
 
 def operations_callback(ops: defaultdict) -> None:
@@ -29,8 +40,8 @@ def operations_callback(ops: defaultdict) -> None:
             f': {inlined_text}'
         )
 
-        # only alf-related posts
-        if 'alf' in record.text.lower():
+        # only alf-related posts that are not archive posts
+        if 'alf' in record.text.lower() and not is_archive_record(record):
             reply_root = reply_parent = None
             if record.reply:
                 reply_root = record.reply.root.uri

--- a/server/data_filter.py
+++ b/server/data_filter.py
@@ -22,7 +22,7 @@ def is_archive_record(record):
     created_at = datetime.datetime.fromisoformat(record.created_at)
     now = datetime.datetime.now(datetime.UTC)
 
-    return now - created_at >= archived_threshold
+    return now - created_at > archived_threshold
 
 
 

--- a/server/data_filter.py
+++ b/server/data_filter.py
@@ -9,7 +9,16 @@ from server.database import db, Post
 
 
 def is_archive_record(record):
-    archived_threshold = datetime.timedelta(minutes=5)
+    # Sometimes users will import old posts from Twitter/X which con flood a feed with
+    # old posts. Unfortunately, the only way to test for this is to look an old
+    # created_at date. However, there are other reasons why a post might have an old
+    # date, such as firehose or firehose consumer outages. It is up to you, the feed
+    # creator to weigh the pros and cons, amd and optionally include this function in
+    # your filter conditions, and adjust the threshold to your liking.
+    #
+    # See https://github.com/MarshalX/bluesky-feed-generator/pull/21
+
+    archived_threshold = datetime.timedelta(days=1)
     created_at = datetime.datetime.fromisoformat(record.created_at)
     now = datetime.datetime.now(datetime.UTC)
 
@@ -41,7 +50,7 @@ def operations_callback(ops: defaultdict) -> None:
         )
 
         # only alf-related posts that are not archive posts
-        if 'alf' in record.text.lower() and not is_archive_record(record):
+        if 'alf' in record.text.lower():
             reply_root = reply_parent = None
             if record.reply:
                 reply_root = record.reply.root.uri


### PR DESCRIPTION
Users importing old posts from Twitter/X can cause a feed to get flooded wold posts that match a keyword. To avoid this, ignore posts with a `created_at` timestamp that is older than 4 minutes.