### PR TITLE
Be more graceful about firehose errors in production

### DIFF
--- a/server/data_stream.py
+++ b/server/data_stream.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 
 from atproto import AtUri, CAR, firehose_models, FirehoseSubscribeReposClient, models, parse_subscribe_repos_message
@@ -51,8 +52,9 @@ def run(name, operations_callback, stream_stop_event=None):
         try:
             _run(name, operations_callback, stream_stop_event)
         except FirehoseError as e:
-            # here we can handle different errors to reconnect to firehose
-            raise e
+            if logger.level == logging.DEBUG:
+                raise e
+            logger.error(f"Firehose error: {e}. Reconnecting to the firehose.")
 
 
 def _run(name, operations_callback, stream_stop_event=None):


### PR DESCRIPTION
Log the exception instead of raising it unless the logging level is set to `DEBUG` (such as when the Flask development server is running)