### PR TITLE
Fix `FEED_URI` empty check in `config.py` since in the `.env` sample it is set by default to the empty string

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -14,10 +14,10 @@ FLASK_RUN_FROM_CLI = os.environ.get('FLASK_RUN_FROM_CLI')
 if FLASK_RUN_FROM_CLI:
     logger.setLevel(logging.DEBUG)
 
-if HOSTNAME is None:
+if not HOSTNAME:
     raise RuntimeError('You should set "HOSTNAME" environment variable first.')
 
-if SERVICE_DID is None:
+if not SERVICE_DID:
     SERVICE_DID = f'did:web:{HOSTNAME}'
 
 

--- a/server/config.py
+++ b/server/config.py
@@ -22,6 +22,6 @@ if SERVICE_DID is None:
 
 
 FEED_URI = os.environ.get('FEED_URI')
-if FEED_URI is None:
+if not FEED_URI:
     raise RuntimeError('Publish your feed first (run publish_feed.py) to obtain Feed URI. '
                        'Set this URI to "FEED_URI" environment variable.')


### PR DESCRIPTION
Fixed FEED_URI null check since in the .env sample it is set by default to empty string, not None.