### PR TITLE
Fix `should_ignore_post` implementation

### DIFF
--- a/server/data_filter.py
+++ b/server/data_filter.py
@@ -28,11 +28,9 @@ def is_archive_post(record: 'models.AppBskyFeedPost.Record') -> bool:
 
 def should_ignore_post(record: 'models.AppBskyFeedPost.Record') -> bool:
     if config.IGNORE_ARCHIVED_POSTS and is_archive_post(record):
-        logger.debug(f'Ignoring archived post: {record.uri}')
         return True
 
     if config.IGNORE_REPLY_POSTS and record.reply:
-        logger.debug(f'Ignoring reply post: {record.uri}')
         return True
 
     return False

--- a/server/data_filter.py
+++ b/server/data_filter.py
@@ -26,11 +26,16 @@ def is_archive_post(record: 'models.AppBskyFeedPost.Record') -> bool:
     return now - created_at > archived_threshold
 
 
-def should_ignore_post(record: 'models.AppBskyFeedPost.Record') -> bool:
+def should_ignore_post(created_post: dict) -> bool:
+    record = created_post['record']
+    uri = created_post['uri']
+
     if config.IGNORE_ARCHIVED_POSTS and is_archive_post(record):
+        logger.debug(f'Ignoring archived post: {uri}')
         return True
 
     if config.IGNORE_REPLY_POSTS and record.reply:
+        logger.debug(f'Ignoring reply post: {uri}')
         return True
 
     return False
@@ -62,7 +67,7 @@ def operations_callback(ops: defaultdict) -> None:
             f': {inlined_text}'
         )
 
-        if should_ignore_post(record):
+        if should_ignore_post(created_post):
             continue
 
         # only python-related posts


### PR DESCRIPTION
…are set to true

It tuns out that post records do not have a `url` attribute, even though they are provided tin post records set as the `reply` or `root` attribute of another record.