### PR TITLE
Fix comment on sample data_filter callback

### DIFF
--- a/server/data_filter.py
+++ b/server/data_filter.py
@@ -46,7 +46,7 @@ def operations_callback(ops: defaultdict) -> None:
     # After our feed alg we can save posts into our DB
     # Also, we should process deleted posts to remove them from our DB and keep it in sync
 
-    # for example, let's create our custom feed that will contain all posts that contains alf related text
+    # for example, let's create our custom feed that will contain all posts that contains 'python' related text
 
     posts_to_create = []
     for created_post in ops[models.ids.AppBskyFeedPost]['created']:


### PR DESCRIPTION
Thanks for this implementation!

As I was checking the `data_filter.py` file, it took me a bit to conciliate the comment about keeping posts that contained "alf related text" with the actual filtering for "`'python'`", until I checked the commit history and also realized that the "alf" bit comes atproto's feed generator starter kit.

This one-liner change just updates that comment so it's aligned with the filtering done later in the file, for legibility.